### PR TITLE
[WIP] Use container id instead of name to find running containers

### DIFF
--- a/dockerspawner/customdockerspawner.py
+++ b/dockerspawner/customdockerspawner.py
@@ -3,6 +3,8 @@ import os
 from tempfile import mkdtemp
 from datetime import timedelta
 
+from docker.errors import APIError
+
 from dockerspawner import DockerSpawner
 from textwrap import dedent
 from traitlets import (
@@ -18,8 +20,6 @@ import git
 
 class CustomDockerSpawner(DockerSpawner):
     def __init__(self, **kwargs):
-        self.repo_url = kwargs['repo_url']
-        self.repo_sha = kwargs.get('last_commit', '')
         super(CustomDockerSpawner, self).__init__(**kwargs)
 
     _git_executor = None
@@ -55,8 +55,14 @@ class CustomDockerSpawner(DockerSpawner):
         """
         return self.executor.submit(self._git, method, *args, **kwargs)
 
-    _escaped_repo_url = None
+    #def get_state(self):
+    #    return {}
 
+    @property
+    def repo_url(self):
+        return self.user.last_repo_url
+
+    _escaped_repo_url = None
     @property
     def escaped_repo_url(self):
         if self._escaped_repo_url is None:
@@ -66,10 +72,32 @@ class CustomDockerSpawner(DockerSpawner):
 
     @property
     def container_name(self):
-        return "{}-{}-{}-{}".format(self.container_prefix,
-                                    self.escaped_name,
-                                    self.escaped_repo_url,
-                                    self.repo_sha)
+        return "{}-{}".format(self.container_prefix,
+                              self.escaped_name,
+                              #self.escaped_repo_url,
+                              #self.repo_sha
+        )
+
+    @gen.coroutine
+    def get_container(self):
+        if not self.container_id:
+            return None
+
+        self.log.debug("Getting container (%s)", self.container_id)
+        try:
+            container = yield self.docker(
+                'inspect_container', self.container_id
+            )
+            self.container_id = container['Id']
+        except APIError as e:
+            if e.response.status_code == 404:
+                self.log.info("Container '%s' is gone", self.container_id)
+                container = None
+                # my container is gone, forget my id
+                self.container_id = ''
+            else:
+                raise
+        return container
 
     @gen.coroutine
     def start(self, image=None):
@@ -89,14 +117,15 @@ class CustomDockerSpawner(DockerSpawner):
         image_name = "everware/{}-{}-{}".format(self.user.name,
                                                 self.escaped_repo_url,
                                                 self.repo_sha)
+
         self.log.debug("Building image {}, dockerfile: {}".format(image_name, dockerfile))
-        build_log = yield gen.with_timeout(timedelta(30),
-                                           self.docker('build',
-                                                       path=tmp_dir,
-                                                       tag=image_name,
-                                                       dockerfile=dockerfile,
-                                                       rm=True)
-        )
+
+        build_log = yield self.docker('build',
+                                      path=tmp_dir,
+                                      tag=image_name,
+                                      dockerfile=dockerfile,
+                                      rm=True)
+
         self.log.debug("".join(str(line) for line in build_log))
         self.log.info("Built docker image {}".format(image_name))
 
@@ -104,7 +133,7 @@ class CustomDockerSpawner(DockerSpawner):
         self.log.debug(images)
 
         yield super(CustomDockerSpawner, self).start(
-            image=image_name
+            image=image_name,
         )
 
     def _env_default(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jupyterhub
 escapism
 docker-py
 GitPython
+requests>=2.7.0


### PR DESCRIPTION
Main change is to use the container ID instead of the name to find the running container. This means we can restore the state of the spawner just from the container ID. No need to store the repository URL anymore. This works best together with `c.Spawner.remove_containers = True` in `jupyterhub_config.py` which removes containers (not images) when the user logs out.